### PR TITLE
Implement MCP MediaWiki server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+MW_API_HOST=wiki.example.com
+MW_API_PATH=/wiki/
+MW_USE_HTTPS=true
+MW_BOT_USER=mcp-bot
+MW_BOT_PASS=secret-password
+MW_WRITE_TOKEN=changeme

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["python", "mcp_mediawiki.py"]

--- a/Usage.md
+++ b/Usage.md
@@ -1,0 +1,39 @@
+# Usage
+
+This guide explains how to build and run the dockerised MCP MediaWiki server.
+
+## Building the image
+
+```bash
+docker build -t mcp-mediawiki .
+```
+
+## Environment variables
+Create a `.env` file with your MediaWiki details:
+
+```
+MW_API_HOST=wiki.example.com
+MW_API_PATH=/wiki/
+MW_USE_HTTPS=true
+MW_BOT_USER=mcp-bot
+MW_BOT_PASS=secret-password
+MW_WRITE_TOKEN=changeme
+```
+
+## Running the server
+
+```bash
+docker run --env-file .env -p 8000:8000 mcp-mediawiki
+```
+
+The server exposes these endpoints:
+
+- `GET /v1/context?title=Page` – fetch page content
+- `GET /v1/search?query=term` – search pages
+- `POST /v1/write` – update a page (requires `Authorization: Bearer $MW_WRITE_TOKEN`)
+
+## Example request
+
+```bash
+curl "http://localhost:8000/v1/context?title=Main_Page"
+```

--- a/mcp_mediawiki.py
+++ b/mcp_mediawiki.py
@@ -1,0 +1,82 @@
+import os
+from fastapi import FastAPI, HTTPException, Header
+from pydantic import BaseModel
+from dotenv import load_dotenv
+import mwclient
+
+load_dotenv()
+
+HOST = os.getenv("MW_API_HOST", "wiki.example.com")
+PATH = os.getenv("MW_API_PATH", "/wiki/")
+USE_HTTPS = os.getenv("MW_USE_HTTPS", "true").lower() == "true"
+BOT_USER = os.getenv("MW_BOT_USER")
+BOT_PASS = os.getenv("MW_BOT_PASS")
+WRITE_TOKEN = os.getenv("MW_WRITE_TOKEN", "secret-token")
+
+SCHEME = "https" if USE_HTTPS else "http"
+
+
+def get_site() -> mwclient.Site:
+    site = mwclient.Site((SCHEME, HOST), path=PATH)
+    if BOT_USER and BOT_PASS:
+        site.login(BOT_USER, BOT_PASS)
+    return site
+
+site = get_site()
+
+app = FastAPI(title="MCP MediaWiki Server")
+
+
+class WritePayload(BaseModel):
+    title: str
+    content: str
+    summary: str
+
+
+@app.get("/v1/context")
+def get_page(title: str):
+    page = site.pages[title]
+    if not page.exists:
+        raise HTTPException(status_code=404, detail="Page not found")
+    text = page.text()
+    return [
+        {
+            "id": f"wiki:{page.page_title}",
+            "name": page.page_title,
+            "content": text,
+            "metadata": {
+                "source": HOST,
+                "url": f"{SCHEME}://{HOST}{PATH}{page.page_title}",
+                "last_modified": page.last_edit[0] if page.last_edit else None,
+                "namespace": page.namespace,
+            },
+        }
+    ]
+
+
+@app.get("/v1/search")
+def search(query: str):
+    results = site.search(query)
+    return [
+        {"title": r["title"], "snippet": r.get("snippet")}
+        for r in results
+    ]
+
+
+@app.post("/v1/write")
+def write_page(payload: WritePayload, Authorization: str = Header(None)):
+    if Authorization != f"Bearer {WRITE_TOKEN}":
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    page = site.pages[payload.title]
+    page.save(text=payload.content, summary=payload.summary)
+    return {
+        "status": "success",
+        "revision_id": page.revision,
+        "url": f"{SCHEME}://{HOST}{PATH}{page.page_title}",
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mcp[cli]
 mwclient
 python-dotenv
+fastapi


### PR DESCRIPTION
## Summary
- implement a FastAPI server that reads/writes/searches MediaWiki pages
- provide a Dockerfile
- add a usage guide
- include example `.env` file
- update requirements with FastAPI

## Testing
- `python -m py_compile mcp_mediawiki.py`


------
https://chatgpt.com/codex/tasks/task_e_6842fbd08fb883308eeb4f1c5d1e94a2