### PR TITLE
Make MediaWiki server MCP compliant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,3 @@ MW_API_PATH=/wiki/
 MW_USE_HTTPS=true
 MW_BOT_USER=mcp-bot
 MW_BOT_PASS=secret-password
-MW_WRITE_TOKEN=changeme

--- a/Usage.md
+++ b/Usage.md
@@ -17,10 +17,17 @@ MW_API_PATH=/wiki/
 MW_USE_HTTPS=true
 MW_BOT_USER=mcp-bot
 MW_BOT_PASS=secret-password
-MW_WRITE_TOKEN=changeme
 ```
 
 ## Running the server
+
+### With Docker Compose
+
+```bash
+docker compose up --build
+```
+
+### Without Compose
 
 ```bash
 docker run --env-file .env mcp-mediawiki
@@ -35,5 +42,12 @@ mcp read wiki://Main_Page
 Update a page using the `update_page` tool:
 
 ```bash
-mcp run update_page --title Main_Page --content "New text" --summary "bot edit" --token "$MW_WRITE_TOKEN"
+mcp run update_page --title Main_Page --content "New text" --summary "bot edit"
 ```
+
+## Using with VSCode
+
+1. Open this folder in VSCode.
+2. Copy `.env.example` to `.env` and adjust the values for your wiki.
+3. Use the integrated terminal to run `python mcp_mediawiki.py` or `docker compose up --build`.
+4. The server will be available at `http://localhost:8000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.9'
+services:
+  mcp-mediawiki:
+    build: .
+    ports:
+      - "8000:8000"
+    env_file:
+      - .env

--- a/mcp_mediawiki.py
+++ b/mcp_mediawiki.py
@@ -10,7 +10,6 @@ PATH = os.getenv("MW_API_PATH", "/wiki/")
 USE_HTTPS = os.getenv("MW_USE_HTTPS", "true").lower() == "true"
 BOT_USER = os.getenv("MW_BOT_USER")
 BOT_PASS = os.getenv("MW_BOT_PASS")
-WRITE_TOKEN = os.getenv("MW_WRITE_TOKEN")
 
 SCHEME = "https" if USE_HTTPS else "http"
 
@@ -33,7 +32,8 @@ def get_page(title: str):
     if not page.exists:
         return {"error": f"Page '{title}' not found"}
     return {
-        "id": f"wiki:{title}",
+        "@id": f"wiki://{title}",
+        "@type": "Document",
         "name": title,
         "content": page.text(),
         "metadata": {
@@ -45,9 +45,7 @@ def get_page(title: str):
 
 
 @mcp.tool()
-def update_page(title: str, content: str, summary: str, token: str):
-    if WRITE_TOKEN and token != WRITE_TOKEN:
-        raise PermissionError("Invalid write token")
+def update_page(title: str, content: str, summary: str):
     page = site.pages[title]
     page.save(text=content, summary=summary)
     return {


### PR DESCRIPTION
## Summary
- return MCP compatible resource information from `get_page`
- drop write token authentication
- provide docker compose for local running
- document usage with VSCode

## Testing
- `python -m py_compile mcp_mediawiki.py`

------
https://chatgpt.com/codex/tasks/task_e_684309ce6284833081b93bf93f70765c