### PR TITLE
Use uvicorn to run server and drop CLI options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,21 +26,7 @@ up:
 # Run the Docker container in detached mode
 .PHONY: up-detached
 up-detached:
-	docker compose up -d
-
-# Run with custom arguments - example: make run-args ARGS="--api-host=mywiki.org --username=bot"
-.PHONY: run-args
-run-args:
-	@if [ -z "$(ARGS)" ]; then \
-		echo "Usage: make run-args ARGS=\"--api-host=mywiki.org --username=bot\""; \
-		exit 1; \
-	fi
-	docker run --rm -it -p 8000:8000 $(IMAGE) $(ARGS)
-
-# Run the Python script directly with arguments
-.PHONY: run-direct
-run-direct:
-	python mcp_mediawiki.py $(ARGS)
+       docker compose up -d
 
 # Run with interactive shell inside container
 .PHONY: shell
@@ -96,10 +82,8 @@ help:
 	@echo "Available targets:"
 	@echo "  make build        - Build the Docker image (tagged as $(IMAGE))"
 	@echo "  make up           - Start the container using docker-compose"
-	@echo "  make up-detached  - Start the container in detached mode"
-	@echo "  make run-args     - Run with custom arguments: make run-args ARGS=\"--api-host=wiki.example.org\""
-	@echo "  make run-direct   - Run Python script directly: make run-direct ARGS=\"--api-host=wiki.example.org\""
-	@echo "  make shell        - Start a shell in the Docker container"
+       @echo "  make up-detached  - Start the container in detached mode"
+       @echo "  make shell        - Start a shell in the Docker container"
 	@echo "  make network-info - Display Docker network information"
 	@echo "  make container-ip - Display container IP address information"
 	@echo "  make down         - Stop the running container"

--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ COPY . .
 # Expose port
 EXPOSE 8000
 
-# Run the application
-CMD ["python", "mcp_mediawiki.py"]
+# Run the application with uvicorn
+CMD ["uvicorn", "mcp_mediawiki:app", "--host", "0.0.0.0", "--port", "8000"]
 This Dockerfile sets up a Python environment, installs dependencies, and runs your mcp_mediawiki application.
 
 ### docker-compose.yml
@@ -281,5 +281,5 @@ This endpoint allows users to search for wiki pages matching a query string.
 
 1. Open the repository in VSCode.
 2. Copy `.env.example` to `.env` and supply your MediaWiki credentials.
-3. Run `python mcp_mediawiki.py` from the integrated terminal or use `docker compose up --build`.
+3. Run `python mcp_mediawiki.py` from the integrated terminal or use `docker compose up --build`. The server is served by **uvicorn**.
 4. Access the server at `http://localhost:8000`.

--- a/Usage.md
+++ b/Usage.md
@@ -40,35 +40,11 @@ make container-ip
 
 If you need to modify the network configuration, edit the `docker-compose.yml` file and adjust the subnet and IP address settings.
 
-## Command Line Arguments
+## Server Configuration
 
-As an alternative to environment variables, you can also pass configuration options as command line arguments:
-
-```bash
-python mcp_mediawiki.py --api-host=wiki.example.com --api-path=/w/ --username=mcp-bot --password=secret-password --use-https=true
-```
-
-When using Docker, you can pass these arguments to the container:
-
-```bash
-docker run -p 8000:8000 mcp-mediawiki --api-host=wiki.example.com --username=mcp-bot
-```
-
-Or use the Makefile for convenience:
-
-```bash
-make run-args ARGS="--api-host=wiki.example.com --username=mcp-bot"
-```
-
-The following arguments are supported:
-
-- `--api-host`: MediaWiki API hostname
-- `--api-path`: MediaWiki API path
-- `--username`: Bot username
-- `--password`: Bot password
-- `--use-https`: Use HTTPS connection (`true` or `false`)
-
-Command line arguments take precedence over environment variables.
+Create a `.env` file with your MediaWiki connection details as shown above. The
+server no longer accepts command line options; all configuration is read from the
+environment.
 
 ## Running the server
 

--- a/mcp_mediawiki.py
+++ b/mcp_mediawiki.py
@@ -1,33 +1,23 @@
 import os
-import argparse
 import sys
 from dotenv import load_dotenv
 import mwclient
 from mcp.server.fastmcp import FastMCP
+import uvicorn
 
 # Add debug logging
 print("Starting MCP MediaWiki server")
 print(f"Python version: {sys.version}")
 
-# Parse command line arguments
-parser = argparse.ArgumentParser(description='MediaWiki MCP Server')
-parser.add_argument('--api-host', help='MediaWiki API host')
-parser.add_argument('--api-path', help='MediaWiki API path')
-parser.add_argument('--username', help='MediaWiki bot username')
-parser.add_argument('--password', help='MediaWiki bot password')
-parser.add_argument('--use-https', choices=['true', 'false'], help='Use HTTPS for connections')
-args = parser.parse_args()
-
 # Load environment variables from .env file
 print("Loading .env file")
 load_dotenv()
 
-# Command line args override environment variables
-HOST = args.api_host or os.getenv("MW_API_HOST", "wiki.example.com")
-PATH = args.api_path or os.getenv("MW_API_PATH", "/wiki/")
-USE_HTTPS = args.use_https if args.use_https else os.getenv("MW_USE_HTTPS", "true").lower() == "true"
-BOT_USER = args.username or os.getenv("MW_BOT_USER")
-BOT_PASS = args.password or os.getenv("MW_BOT_PASS")
+HOST = os.getenv("MW_API_HOST", "wiki.example.com")
+PATH = os.getenv("MW_API_PATH", "/wiki/")
+USE_HTTPS = os.getenv("MW_USE_HTTPS", "true").lower() == "true"
+BOT_USER = os.getenv("MW_BOT_USER")
+BOT_PASS = os.getenv("MW_BOT_PASS")
 
 print(f"Configuration: HOST={HOST}, PATH={PATH}, HTTPS={USE_HTTPS}")
 print(f"Bot user: {BOT_USER}")
@@ -76,15 +66,13 @@ def update_page(title: str, content: str, summary: str):
     }
 
 
+app = mcp.streamable_http_app()
+
+
 if __name__ == "__main__":
-    print("Starting MCP server...")
+    print("Starting MCP server with uvicorn...")
     try:
-        print("Running mcp.run()")
-        # By default, FastMCP's run() method blocks, keeping the server running
-        # Make sure to use host='0.0.0.0' so it's accessible from outside the container
-        mcp.run(host='0.0.0.0', port=8000)
-        # This should not be reached unless the server shuts down
-        print("Server has shut down.")
+        uvicorn.run(app, host="0.0.0.0", port=8000)
     except Exception as e:
         print(f"Error running MCP server: {e}")
         import traceback

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 mcp[cli]
 mwclient
 python-dotenv
+uvicorn


### PR DESCRIPTION
## Summary
- launch server with uvicorn instead of FastMCP.run
- rely solely on `.env` variables for configuration
- document uvicorn usage in README and Usage
- remove obsolete CLI parameter instructions and Makefile targets
- add `uvicorn` to `requirements.txt`

## Testing
- `python -m py_compile mcp_mediawiki.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68431aa01ae0833082a2fbbfda31c7d1