### PR TITLE
Fix VSCode MCP connection

### DIFF
--- a/mcp_mediawiki.py
+++ b/mcp_mediawiki.py
@@ -34,7 +34,9 @@ def get_site() -> mwclient.Site:
 
 site = get_site()
 
-mcp = FastMCP("mcp_mediawiki")
+# Mount the Streamable HTTP server at the root path so VS Code can
+# communicate with the server without additional configuration.
+mcp = FastMCP("mcp_mediawiki", streamable_http_path="/")
 
 
 @mcp.resource("wiki://{title}")


### PR DESCRIPTION
## Summary
- mount FastMCP at root so VS Code connects successfully

## Testing
- `python -m py_compile mcp_mediawiki.py`


------
https://chatgpt.com/codex/tasks/task_e_68431f6b4e0c8330a3f05680cd23d32a