### PR TITLE
Add tools and health route

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ The MediaWiki MCP (Model Context Protocol) server provides a structured interfac
 
 This server exposes MCP resources and tools instead of traditional REST endpoints.
 
+The server mounts its MCP transport at `/mcp` and the root route `/` returns a
+simple JSON health payload so VS Code's MCP extension can connect without 404
+errors.
+
+Available tools include:
+
+* `update_page` – create or edit pages (supports optional `dry_run`)
+* `search_pages` – search pages by title keyword
+* `server_status` – show configuration and MediaWiki version
+* `get_page_history` – fetch recent revisions of a page
+
 ### `wiki://{title}`
 
 Fetches the full content of the requested page title.
@@ -283,4 +294,4 @@ This endpoint allows users to search for wiki pages matching a query string.
 1. Open the repository in VSCode.
 2. Copy `.env.example` to `.env` and supply your MediaWiki credentials.
 3. Run `python mcp_mediawiki.py` from the integrated terminal or use `docker compose up --build`. The server is served by **uvicorn**.
-4. Access the server at `http://localhost:8000`.
+4. Access `http://localhost:8000/` for a JSON health response. The MCP transport is available at `http://localhost:8000/mcp` which the extension uses automatically.

--- a/mcp_mediawiki.py
+++ b/mcp_mediawiki.py
@@ -1,16 +1,24 @@
 import os
 import sys
+import logging
+from typing import Annotated
+
 from dotenv import load_dotenv
 import mwclient
+from pydantic import BaseModel, Field
 from mcp.server.fastmcp import FastMCP
 import uvicorn
 
-# Add debug logging
-print("Starting MCP MediaWiki server")
-print(f"Python version: {sys.version}")
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Startup logs
+logger.info("Starting MCP MediaWiki server")
+logger.info(f"Python version: {sys.version}")
 
 # Load environment variables from .env file
-print("Loading .env file")
+logger.info("Loading .env file")
 load_dotenv()
 
 HOST = os.getenv("MW_API_HOST", "wiki.example.com")
@@ -19,8 +27,8 @@ USE_HTTPS = os.getenv("MW_USE_HTTPS", "true").lower() == "true"
 BOT_USER = os.getenv("MW_BOT_USER")
 BOT_PASS = os.getenv("MW_BOT_PASS")
 
-print(f"Configuration: HOST={HOST}, PATH={PATH}, HTTPS={USE_HTTPS}")
-print(f"Bot user: {BOT_USER}")
+logger.info(f"Configuration: HOST={HOST}, PATH={PATH}, HTTPS={USE_HTTPS}")
+logger.info(f"Bot user: {BOT_USER}")
 
 SCHEME = "https" if USE_HTTPS else "http"
 
@@ -34,50 +42,148 @@ def get_site() -> mwclient.Site:
 
 site = get_site()
 
-# Mount the Streamable HTTP server at the root path so VS Code can
-# communicate with the server without additional configuration.
-mcp = FastMCP("mcp_mediawiki", streamable_http_path="/")
+
+class UpdatePageInput(BaseModel):
+    """Input model for updating or creating a page."""
+
+    title: Annotated[str, Field(min_length=1, description="Wiki page title")]
+    content: Annotated[str, Field(description="Wikitext content to save")]
+    summary: Annotated[str, Field(description="Edit summary")]
+    dry_run: Annotated[bool, Field(False, description="Preview the edit without saving")]
+
+
+class SearchPagesInput(BaseModel):
+    query: Annotated[str, Field(min_length=1, description="Title keyword to search for")]
+
+
+class PageHistoryInput(BaseModel):
+    title: Annotated[str, Field(min_length=1, description="Page title")]
+    limit: Annotated[int, Field(5, ge=1, le=50, description="Number of revisions to fetch")]
+
+# Mount the Streamable HTTP server at /mcp so the root path can
+# return a simple JSON health response for VS Code and other tools.
+mcp = FastMCP("mcp_mediawiki", streamable_http_path="/mcp")
 
 
 @mcp.resource("wiki://{title}")
 def get_page(title: str):
+    """Return the full wikitext and metadata for a page."""
+    logger.info("get_page called", extra={"title": title})
     page = site.pages[title]
     if not page.exists:
         return {"error": f"Page '{title}' not found"}
-    return {
+
+    categories = [c.name for c in page.categories()]
+    info = {
         "@id": f"wiki://{title}",
         "@type": "Document",
         "name": title,
         "content": page.text(),
         "metadata": {
             "url": f"{SCHEME}://{HOST}{PATH}index.php/{title}",
-            "last_modified": next(page.revisions())['timestamp'],
+            "last_modified": next(page.revisions())["timestamp"],
             "namespace": page.namespace,
+            "length": page.length,
+            "protection": page.protection,
+            "categories": categories,
         },
     }
+    return info
 
 
 @mcp.tool(description="Create or edit a page with the provided content")
-def update_page(title: str, content: str, summary: str):
+def update_page(
+    title: str,
+    content: str,
+    summary: str,
+    dry_run: bool = False,
+):
     """Create or update a wiki page."""
-    page = site.pages[title]
-    page.save(text=content, summary=summary)
+    params = UpdatePageInput(
+        title=title, content=content, summary=summary, dry_run=dry_run
+    )
+    logger.info("update_page called", extra=params.model_dump())
+
+    if params.dry_run:
+        return {
+            "status": "dry-run",
+            "title": params.title,
+            "content": params.content,
+            "summary": params.summary,
+        }
+
+    page = site.pages[params.title]
+    page.save(text=params.content, summary=params.summary)
     return {
         "status": "success",
-        "title": title,
-        "url": f"{SCHEME}://{HOST}/wiki/{title}",
+        "title": params.title,
+        "url": f"{SCHEME}://{HOST}/wiki/{params.title}",
     }
+
+
+@mcp.tool(description="Search wiki pages by title keyword")
+def search_pages(query: str, limit: int = 5):
+    """Search pages by title."""
+    params = SearchPagesInput(query=query)
+    logger.info("search_pages called", extra=params.model_dump())
+    results = site.search(params.query, limit=limit)
+    return [
+        {"title": r["title"], "snippet": r.get("snippet")}
+        for r in results
+    ]
+
+
+@mcp.tool(description="Get basic server configuration and version info")
+def server_status():
+    """Return server configuration details."""
+    logger.info("server_status called")
+    version = site.site_info.get("generator")
+    return {
+        "host": HOST,
+        "path": PATH,
+        "scheme": SCHEME,
+        "mediawiki_version": version,
+    }
+
+
+@mcp.tool(description="Get the last N revisions of a page")
+def get_page_history(title: str, limit: int = 5):
+    """Return recent revision history for a page."""
+    params = PageHistoryInput(title=title, limit=limit)
+    logger.info("get_page_history called", extra=params.model_dump())
+    page = site.pages[params.title]
+    if not page.exists:
+        return {"error": f"Page '{params.title}' not found"}
+    revisions = [
+        {
+            "revid": rev.get("revid"),
+            "user": rev.get("user"),
+            "timestamp": rev.get("timestamp"),
+            "comment": rev.get("comment"),
+        }
+        for rev in page.revisions(limit=params.limit)
+    ]
+    return revisions
 
 
 app = mcp.streamable_http_app()
 
 
+@app.get("/")
+def root() -> dict[str, str]:
+    """Return server health information."""
+    logger.info("root endpoint called")
+    return {
+        "status": "ok",
+        "server": "mcp-mediawiki",
+        "streamable_http_path": "/mcp",
+    }
+
+
 if __name__ == "__main__":
-    print("Starting MCP server with uvicorn...")
+    logger.info("Starting MCP server with uvicorn...")
     try:
         uvicorn.run(app, host="0.0.0.0", port=8000)
     except Exception as e:
-        print(f"Error running MCP server: {e}")
-        import traceback
-        traceback.print_exc()
+        logger.exception(f"Error running MCP server: {e}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- add new tools for searching pages, getting history, checking server status
- validate tool input with Pydantic
- add dry-run mode to page updates
- expose root route for health checks and mount MCP server at `/mcp`
- log tool calls and startup details
- document new endpoints and VSCode usage

## Testing
- `pytest -q`
- `python -m py_compile mcp_mediawiki.py`


------
https://chatgpt.com/codex/tasks/task_e_684323579aa0833081363301269e6c27