### PR TITLE
Add get_page tool and refine update_page

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -74,8 +74,8 @@ def test_root_endpoint(server):
 
 def test_get_page_success(server):
     result = server.get_page('Existing')
-    assert result['name'] == 'Existing'
-    assert result['metadata']['namespace'] == 0
+    assert result.name == 'Existing'
+    assert result.metadata.namespace == 0
 
 
 def test_get_page_not_found(server):
@@ -85,12 +85,12 @@ def test_get_page_not_found(server):
 
 def test_update_page_dry_run(server):
     result = server.update_page('Existing', 'new', 's', dry_run=True)
-    assert result['status'] == 'dry-run'
+    assert result.status == 'dry-run'
 
 
 def test_update_page_save(server):
     result = server.update_page('Existing', 'updated', 'sum')
-    assert result['status'] == 'success'
+    assert result.status == 'success'
     page = server.site.pages['Existing']
     assert page.saved and page.saved[-1] == ('updated', 'sum')
 


### PR DESCRIPTION
## Summary
- expose `get_page` as a tool that returns structured page data
- add metadata and result models for clean responses
- enhance `update_page` with a clear description, structured return and dry-run support
- adjust unit tests for new return models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432dc038b88330b6c6787f11c11fe4